### PR TITLE
Phase 1: bump dotenv, toad-scheduler, and dateformat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "dependencies": {
         "app-root-path": "^3.1.0",
         "compression": "^1.8.1",
-        "dateformat": "^4.6.3",
+        "dateformat": "^5.0.3",
         "debug": "^4.4.3",
-        "dotenv": "^16.6.1",
+        "dotenv": "^17.4.2",
         "express": "^4.22.1",
         "express-async-handler": "^1.2.0",
         "format-duration": "^3.0.2",
@@ -21,7 +21,7 @@
         "mqtt": "^5.15.1",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7",
-        "toad-scheduler": "^3.1.0"
+        "toad-scheduler": "^4.0.1"
       },
       "devDependencies": {
         "@types/chai": "^4.3.20",
@@ -41,6 +41,9 @@
         "ts-node": "^10.9.2",
         "ts-node-register": "^1.0.0",
         "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=18.2.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1513,9 +1516,19 @@
       "dev": true
     },
     "node_modules/croner": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/croner/-/croner-8.1.2.tgz",
-      "integrity": "sha512-ypfPFcAXHuAZRCzo3vJL6ltENzniTjwe/qsLleH1V2/7SRDjgvRQyrLmumFTLmjFax4IuSxfGXEn79fozXcJog==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
+      "integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
+      "funding": [
+        {
+          "type": "other",
+          "url": "https://paypal.me/hexagonpp"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/hexagon"
+        }
+      ],
       "license": "MIT",
       "engines": {
         "node": ">=18.0"
@@ -1536,11 +1549,12 @@
       }
     },
     "node_modules/dateformat": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
-      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-5.0.3.tgz",
+      "integrity": "sha512-Kvr6HmPXUMerlLcLF+Pwq3K7apHpYmGDVqrxcDasBg86UcKeTSNWbEzU8bwdXnxnR44FtMhJAxI4Bov6Y/KUfA==",
+      "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">=12.20"
       }
     },
     "node_modules/debug": {
@@ -1683,9 +1697,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -4616,12 +4630,12 @@
       }
     },
     "node_modules/toad-scheduler": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/toad-scheduler/-/toad-scheduler-3.1.0.tgz",
-      "integrity": "sha512-ZTwsGMWyKTOokgTmIvjPIvkT3ZiPFgkAi8L0OLONOcSc/BUDPRzNMOfVWZzugIAxyntvY0Nzy1etNk+31Q4FXQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/toad-scheduler/-/toad-scheduler-4.0.1.tgz",
+      "integrity": "sha512-utMUvxJmzqmuQzkqFyJdspuDvoVsO5SgQUvEtyZcrVvSwHLOttD+m6SjJZ2u6LoKw5k7zh4vihqjvENbHLfdNA==",
       "license": "MIT",
       "dependencies": {
-        "croner": "^8.1.2"
+        "croner": "^10.0.1"
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "dependencies": {
     "app-root-path": "^3.1.0",
     "compression": "^1.8.1",
-    "dateformat": "^4.6.3",
+    "dateformat": "^5.0.3",
     "debug": "^4.4.3",
-    "dotenv": "^16.6.1",
+    "dotenv": "^17.4.2",
     "express": "^4.22.1",
     "express-async-handler": "^1.2.0",
     "format-duration": "^3.0.2",
@@ -28,7 +28,7 @@
     "mqtt": "^5.15.1",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7",
-    "toad-scheduler": "^3.1.0"
+    "toad-scheduler": "^4.0.1"
   },
   "devDependencies": {
     "@types/chai": "^4.3.20",


### PR DESCRIPTION
## Summary
- bump dotenv to v17
- bump toad-scheduler to v4
- bump dateformat to v5

## Scope
- dependency-only update in package manifests
- no source code changes

## Validation
- targeted specs passed: configuration, jobScheduler, messageForwardingService, dataStore, forwardersRouter, passiveStatistics, statistics index
- npm test passed (141 passing)
- npm run build passed

## Risk
- low-impact runtime dependency refresh
- no behavior changes observed in tests

## Notes
- Work performed in dedicated git worktree branch chore/major-upgrades-p1